### PR TITLE
Update okta_authenticationApi.mustache

### DIFF
--- a/openapi3/codegen-templates/okta_authenticationApi.mustache
+++ b/openapi3/codegen-templates/okta_authenticationApi.mustache
@@ -62,7 +62,8 @@ function Invoke-OktaEstablishAccessToken {
         $DeviceUrl = $LocalVarResult.Response.verification_uri_complete 
         $DeviceCode = $LocalVarResult.Response.device_code
 
-        Write-Host "Open your browser and navigate to the following URL to begin the Okta device authorization for the Powershell CLI: " $DeviceUrl
+        Write-Host "Open your browser and navigate to the following URL to begin the Okta device authorization for the PowerShell CLI:"
+        Write-Host $DeviceUrl
         
         $keepPolling = $true
         $CountPolling = 1


### PR DESCRIPTION
fix typo

also, line wraps breaks the url into 2. old terminals don't support clickable links and copying the link across 2 lines is awkward. placing the link on 1 line makes it easier to copy.