### PR TITLE
Add check of IsValueType to prevent Stack Overflow (#43)

### DIFF
--- a/src/Okta.PowerShell/Client/JsonHelper.ps1
+++ b/src/Okta.PowerShell/Client/JsonHelper.ps1
@@ -19,7 +19,7 @@ function Remove-NullProperties {
 
     $NewObject = @{ }
     
-    if ($InputObject -is [string] -or $InputObject.GetType().IsPrimitive) {
+    if ($InputObject -is [string] -or $InputObject.GetType().IsPrimitive -or $InputObject.GetType().IsValueType) {
         return $InputObject
     }
     elseif ($InputObject -is [System.Collections.IDictionary]) {


### PR DESCRIPTION
This adds to the early out logic at the top of Remove-NullProperties so that when objects like DateTime are passed in it does not loop through child properties until hitting the stack limit

Issue #43 - https://github.com/okta/okta-powershell-cli/issues/43