### PR TITLE
Add forced casting for Arrays in Remove-NullProperties (#50)

### DIFF
--- a/src/Okta.PowerShell/Client/JsonHelper.ps1
+++ b/src/Okta.PowerShell/Client/JsonHelper.ps1
@@ -33,7 +33,12 @@ function Remove-NullProperties {
         $PropertyList = $InputObject.PSObject.Properties | Where-Object { $null -ne $_.Value }
         
         foreach ($Property in $PropertyList) { 
-            $NewObject[$Property.Name] = Remove-NullProperties $Property.Value
+            if($Property.Value -is [array]){
+                # explicit cast to avoid arrays to be converted to object (i.e @('foo'))
+                $NewObject[$Property.Name] = [array]@(Remove-NullProperties $Property.Value)
+            }else{
+                $NewObject[$Property.Name] = Remove-NullProperties $Property.Value
+            }
         }
     }
 


### PR DESCRIPTION
This adds a forced cast inside the method that prevents Powershell from converting a single valued array to an object.

This pr does not include changes to the test methods as Im not sure how the team would intend the use case to be tested

Its a revisit on #35

Issue #50