### PR TITLE
Fix issues with the retry logic in the OktaApiClient and OktaRetryApi classes (#61)

### DIFF
--- a/openapi3/codegen-templates/api_client.mustache
+++ b/openapi3/codegen-templates/api_client.mustache
@@ -163,7 +163,8 @@ function Invoke-{{{apiNamePrefix}}}ApiClient {
                                         -ErrorAction Stop `
                                         -UseBasicParsing `
                                         -SkipCertificateCheck `
-                                        -UserAgent $OktaUserAgent
+                                        -UserAgent $OktaUserAgent `
+                                        -SkipHttpErrorCheck
             } else {
                 # skip certification check, use proxy
                 $RawResponse = Invoke-WebRequest -Uri $UriBuilder.Uri `
@@ -175,7 +176,8 @@ function Invoke-{{{apiNamePrefix}}}ApiClient {
                                         -SkipCertificateCheck `
                                         -Proxy $Configuration["Proxy"].GetProxy($UriBuilder.Uri) `
                                         -ProxyUseDefaultCredentials `
-                                        -UserAgent $OktaUserAgent
+                                        -UserAgent $OktaUserAgent `
+                                        -SkipHttpErrorCheck
             }
         } else {
             if ($null -eq $Configuration["Proxy"]) {
@@ -186,7 +188,8 @@ function Invoke-{{{apiNamePrefix}}}ApiClient {
                                         -Body $RequestBody `
                                         -ErrorAction Stop `
                                         -UseBasicParsing `
-                                        -UserAgent $OktaUserAgent
+                                        -UserAgent $OktaUserAgent `
+                                        -SkipHttpErrorCheck
             } else {
                 # perform certification check, use proxy
                 $RawResponse = Invoke-WebRequest -Uri $UriBuilder.Uri `
@@ -197,7 +200,8 @@ function Invoke-{{{apiNamePrefix}}}ApiClient {
                                         -UseBasicParsing `
                                         -Proxy $Configuration["Proxy"].GetProxy($UriBuilder.Uri) `
                                         -ProxyUseDefaultCredentials `
-                                        -UserAgent $OktaUserAgent
+                                        -UserAgent $OktaUserAgent `
+                                        -SkipHttpErrorCheck
             }
 
             $Response = $null
@@ -217,6 +221,7 @@ function Invoke-{{{apiNamePrefix}}}ApiClient {
                     $RetryCount = $RetryCount + 1
                     $RequestId = $Headers['X-Okta-Request-Id'][0]
                     AddRetryHeaders -Headers $HeaderParameters -RequestId $RequestId -RetryCount $RetryCount
+                    Write-Verbose "Hit Rate limit: Retrying request after $WaitInMilliseconds milliseconds"
                     Start-Sleep -Milliseconds $WaitInMilliseconds
                 }
                 else {

--- a/openapi3/codegen-templates/okta_retryApi.mustache
+++ b/openapi3/codegen-templates/okta_retryApi.mustache
@@ -86,12 +86,15 @@ function CalculateDelay {
 
     $Configuration = Get-OktaConfiguration
 
-    if ($null -eq $Headers['X-Rate-Limit-Reset']) {
-        throw "Error! The required header `X-Rate-Limit-Reset` missing when calling CalculateDelay." 
+    if ($null -eq $Headers['x-rate-limit-reset']) {
+        throw "Error! The required header `x-rate-limit-reset` missing when calling CalculateDelay." 
     }
     
-    $RateLimitReset = Get-Date -Date $Headers["X-Rate-Limit-Reset"][0]
-    $RetryAtUtcTime = $RateLimitReset.ToUniversalTime()
+    $RateLimitResetEpoch = $Headers["x-rate-limit-reset"][0]
+    # this is a unich seconds since epoch time, so we convert to date
+    $RateLimitResetUTC = New-Object DateTime(1970, 1, 1, 0, 0, 0, 0)
+    $RateLimitResetUTC = $RateLimitResetUTC.addSeconds($RateLimitResetEpoch)
+    $RetryAtUtcTime = $RateLimitResetUTC
     
 
     if ($null -eq $Headers["Date"]) {

--- a/src/Okta.PowerShell/Client/OktaRetryApi.ps1
+++ b/src/Okta.PowerShell/Client/OktaRetryApi.ps1
@@ -86,12 +86,15 @@ function CalculateDelay {
 
     $Configuration = Get-OktaConfiguration
 
-    if ($null -eq $Headers['X-Rate-Limit-Reset']) {
-        throw "Error! The required header `X-Rate-Limit-Reset` missing when calling CalculateDelay." 
+    if ($null -eq $Headers['x-rate-limit-reset']) {
+        throw "Error! The required header `x-rate-limit-reset` missing when calling CalculateDelay." 
     }
     
-    $RateLimitReset = Get-Date -Date $Headers["X-Rate-Limit-Reset"][0]
-    $RetryAtUtcTime = $RateLimitReset.ToUniversalTime()
+    $RateLimitResetEpoch = $Headers["x-rate-limit-reset"][0]
+    # this is a unich seconds since epoch time, so we convert to date
+    $RateLimitResetUTC = New-Object DateTime(1970, 1, 1, 0, 0, 0, 0)
+    $RateLimitResetUTC = $RateLimitResetUTC.addSeconds($RateLimitResetEpoch)
+    $RetryAtUtcTime = $RateLimitResetUTC
     
 
     if ($null -eq $Headers["Date"]) {

--- a/src/Okta.PowerShell/Private/OktaApiClient.ps1
+++ b/src/Okta.PowerShell/Private/OktaApiClient.ps1
@@ -151,7 +151,8 @@ function Invoke-OktaApiClient {
                                         -ErrorAction Stop `
                                         -UseBasicParsing `
                                         -SkipCertificateCheck `
-                                        -UserAgent $OktaUserAgent
+                                        -UserAgent $OktaUserAgent `
+                                        -SkipHttpErrorCheck
             } else {
                 # skip certification check, use proxy
                 $RawResponse = Invoke-WebRequest -Uri $UriBuilder.Uri `
@@ -163,7 +164,8 @@ function Invoke-OktaApiClient {
                                         -SkipCertificateCheck `
                                         -Proxy $Configuration["Proxy"].GetProxy($UriBuilder.Uri) `
                                         -ProxyUseDefaultCredentials `
-                                        -UserAgent $OktaUserAgent
+                                        -UserAgent $OktaUserAgent `
+                                        -SkipHttpErrorCheck
             }
         } else {
             if ($null -eq $Configuration["Proxy"]) {
@@ -174,7 +176,8 @@ function Invoke-OktaApiClient {
                                         -Body $RequestBody `
                                         -ErrorAction Stop `
                                         -UseBasicParsing `
-                                        -UserAgent $OktaUserAgent
+                                        -UserAgent $OktaUserAgent `
+                                        -SkipHttpErrorCheck
             } else {
                 # perform certification check, use proxy
                 $RawResponse = Invoke-WebRequest -Uri $UriBuilder.Uri `
@@ -185,7 +188,8 @@ function Invoke-OktaApiClient {
                                         -UseBasicParsing `
                                         -Proxy $Configuration["Proxy"].GetProxy($UriBuilder.Uri) `
                                         -ProxyUseDefaultCredentials `
-                                        -UserAgent $OktaUserAgent
+                                        -UserAgent $OktaUserAgent `
+                                        -SkipHttpErrorCheck
             }
 
             $Response = $null
@@ -205,6 +209,7 @@ function Invoke-OktaApiClient {
                     $RetryCount = $RetryCount + 1
                     $RequestId = $Headers['X-Okta-Request-Id'][0]
                     AddRetryHeaders -Headers $HeaderParameters -RequestId $RequestId -RetryCount $RetryCount
+                    Write-Verbose "Hit Rate limit: Retrying request after $WaitInMilliseconds milliseconds"
                     Start-Sleep -Milliseconds $WaitInMilliseconds
                 }
                 else {

--- a/tests/Internal/OktaApiClient.Tests.ps1
+++ b/tests/Internal/OktaApiClient.Tests.ps1
@@ -5,7 +5,8 @@ Context 'Invoke-OktaApiClient - 429 Responses' {
         $Config.RequestTimeout = $null
         $Now = Get-Date # Used as a reference for the test. Indicates when the request was executed
         $ResetDate = $Now.AddSeconds(3) # Indicates when one should retry
-        
+        $ResetDateEpoch = $ResetDate.ToUniversalTime().Subtract((New-Object DateTime(1970, 1, 1, 0, 0, 0, 0))).TotalSeconds
+
         Mock -ModuleName Okta.PowerShell Get-OktaConfiguration { return $Config } -Verifiable
         
         $Response = [PSCustomObject]@{
@@ -13,7 +14,7 @@ Context 'Invoke-OktaApiClient - 429 Responses' {
             Headers =  @{
                 "Date" = @($Now)
                 "Content-Type" = @('application/json; charset=utf-8')
-                "X-Rate-Limit-Reset" = @($ResetDate)
+                "x-rate-limit-reset" = @($ResetDateEpoch)
                 "X-Okta-Request-Id" = @("foo")
             }
             StatusCode = 429
@@ -33,6 +34,7 @@ Context 'Invoke-OktaApiClient - 429 Responses' {
         $Config.RequestTimeout = 100000
         $Now = Get-Date # Used as a reference for the test. Indicates when the request was executed
         $ResetDate = $Now.AddSeconds(3) # Indicates when one should retry
+        $ResetDateEpoch = $ResetDate.ToUniversalTime().Subtract((New-Object DateTime(1970, 1, 1, 0, 0, 0, 0))).TotalSeconds
         
         Mock -ModuleName Okta.PowerShell Get-OktaConfiguration { return $Config } -Verifiable
         
@@ -41,7 +43,7 @@ Context 'Invoke-OktaApiClient - 429 Responses' {
             Headers =  @{
                 "Date" = @($Now)
                 "Content-Type" = @('application/json; charset=utf-8')
-                "X-Rate-Limit-Reset" = @($ResetDate)
+                "x-rate-limit-reset" = @($ResetDateEpoch)
                 "X-Okta-Request-Id" = @("foo")
             }
             StatusCode = 429
@@ -61,6 +63,7 @@ Context 'Invoke-OktaApiClient - 429 Responses' {
         $Config.RequestTimeout = 1000
         $Now = Get-Date # Used as a reference for the test. Indicates when the request was executed
         $ResetDate = $Now.AddSeconds(3) # Indicates when one should retry
+        $ResetDateEpoch = $ResetDate.ToUniversalTime().Subtract((New-Object DateTime(1970, 1, 1, 0, 0, 0, 0))).TotalSeconds
         
         Mock -ModuleName Okta.PowerShell Get-OktaConfiguration { return $Config } -Verifiable
 
@@ -71,7 +74,7 @@ Context 'Invoke-OktaApiClient - 429 Responses' {
             Headers =  @{
                 "Date" = @($Now)
                 "Content-Type" = @('application/json; charset=utf-8')
-                "X-Rate-Limit-Reset" = @($ResetDate)
+                "x-rate-limit-reset" = @($ResetDateEpoch)
                 "X-Okta-Request-Id" = @("foo")
             }
             StatusCode = 429
@@ -92,6 +95,7 @@ Context 'Invoke-OktaApiClient - 429 Responses' {
         $Config.RequestTimeout = 1000
         $Now = Get-Date # Used as a reference for the test. Indicates when the request was executed
         $ResetDate = $Now.AddSeconds(3) # Indicates when one should retry
+        $ResetDateEpoch = $ResetDate.ToUniversalTime().Subtract((New-Object DateTime(1970, 1, 1, 0, 0, 0, 0))).TotalSeconds
         
         Mock -ModuleName Okta.PowerShell Get-OktaConfiguration { return $Config } -Verifiable
 
@@ -102,7 +106,7 @@ Context 'Invoke-OktaApiClient - 429 Responses' {
             Headers =  @{
                 "Date" = @($Now)
                 "Content-Type" = @('application/json; charset=utf-8')
-                "X-Rate-Limit-Reset" = @($ResetDate)
+                "x-rate-limit-reset" = @($ResetDateEpoch)
                 "X-Okta-Request-Id" = @("foo")
             }
             StatusCode = 400


### PR DESCRIPTION
Fix issues with the retry logic in the OktaApiClient and OktaRetryApi classes
* The OktaApiClient class was not correctly handling a non 200 response code
* The OktaRetryApi class was searching for a header field using incorrect case
* The OktaRetryApi class was trying to parse a Unix Epoch number as a string date
* Also added a verbose message so the user knows how long they waiting for the retry

Root cause was missing a switch on API calls and the retyr logic not matching the Okta API names and data types

Issue #61 