### PR TITLE
Changes to Set-OktaConfiguration to support 0 values to be passed (#70)

### DIFF
--- a/openapi3/codegen-templates/configuration.mustache
+++ b/openapi3/codegen-templates/configuration.mustache
@@ -192,7 +192,7 @@ function Set-{{{apiNamePrefix}}}Configuration {
             $Script:Configuration['MaxRetries'] = $MaxRetries
         }
 
-        If ($PSBoundParameters.ContainsKey("$RequestTimeout")) {
+        If ($PSBoundParameters.ContainsKey("RequestTimeout")) {
             $Script:Configuration['RequestTimeout'] = $RequestTimeout
         }
 

--- a/openapi3/codegen-templates/configuration.mustache
+++ b/openapi3/codegen-templates/configuration.mustache
@@ -188,11 +188,11 @@ function Set-{{{apiNamePrefix}}}Configuration {
             $Script:Configuration['Proxy'] = $null
         }
 
-         If ($MaxRetries) {
+         If ($PSBoundParameters.ContainsKey("MaxRetries")) {
             $Script:Configuration['MaxRetries'] = $MaxRetries
         }
 
-        If ($RequestTimeout) {
+        If ($PSBoundParameters.ContainsKey("$RequestTimeout")) {
             $Script:Configuration['RequestTimeout'] = $RequestTimeout
         }
 

--- a/src/Okta.PowerShell/Client/OktaConfiguration.ps1
+++ b/src/Okta.PowerShell/Client/OktaConfiguration.ps1
@@ -199,7 +199,7 @@ function Set-OktaConfiguration {
             $Script:Configuration['MaxRetries'] = $MaxRetries
         }
 
-        If ($PSBoundParameters.ContainsKey("$RequestTimeout")) {
+        If ($PSBoundParameters.ContainsKey("RequestTimeout")) {
             $Script:Configuration['RequestTimeout'] = $RequestTimeout
         }
 

--- a/src/Okta.PowerShell/Client/OktaConfiguration.ps1
+++ b/src/Okta.PowerShell/Client/OktaConfiguration.ps1
@@ -195,11 +195,11 @@ function Set-OktaConfiguration {
             $Script:Configuration['Proxy'] = $null
         }
 
-         If ($MaxRetries) {
+         If ($PSBoundParameters.ContainsKey("MaxRetries")) {
             $Script:Configuration['MaxRetries'] = $MaxRetries
         }
 
-        If ($RequestTimeout) {
+        If ($PSBoundParameters.ContainsKey("$RequestTimeout")) {
             $Script:Configuration['RequestTimeout'] = $RequestTimeout
         }
 


### PR DESCRIPTION
Uses PSBoundParameter.ContainsKey rather than the if of the variable as if the passed in value is 0 or $false the set is not done

same issue as #56, but in a different template

Issue #70