### PR TITLE
Fix for ApiKey not being sent to Authorization Header (#91)

### DIFF
--- a/openapi3/codegen-templates/api_client.mustache
+++ b/openapi3/codegen-templates/api_client.mustache
@@ -72,6 +72,11 @@ function Invoke-{{{apiNamePrefix}}}ApiClient {
         $HeaderParameters[$header.Name] = $header.Value
     }
 
+    # Add the Authorization Header if APIKey and ApiKeyPrefix were presented
+    if ($Configuration.ApiKey -and $Configuration.ApiKeyPrefix) {
+        $HeaderParameters["Authorization"] = "$($Configuration.ApiKeyPrefix) $($Configuration.ApiKey.apitoken)"
+    }
+
     # construct URL query string
     $HttpValues = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
     foreach ($Parameter in $QueryParameters.GetEnumerator()) {

--- a/src/Okta.PowerShell/Private/OktaApiClient.ps1
+++ b/src/Okta.PowerShell/Private/OktaApiClient.ps1
@@ -79,10 +79,9 @@ function Invoke-OktaApiClient {
         $HeaderParameters[$header.Name] = $header.Value
     }
 
+    # Add the Authorization Header if APIKey and ApiKeyPrefix were presented
     if ($Configuration.ApiKey -and $Configuration.ApiKeyPrefix) {
-        $headers = @{
-            Authorization = "$($Configuration.ApiKeyPrefix) $($Configuration.ApiKey.apitoken)"
-        }
+        $HeaderParameters["Authorization"] = "$($Configuration.ApiKeyPrefix) $($Configuration.ApiKey.apitoken)"
     }
     
     # construct URL query string


### PR DESCRIPTION
This changes the code and its mustache template to add the key to the Authorization header that is sent to the API

Fixes Issue #91 