### PR TITLE
Fix: Prevent infinite recursion in Remove-NullProperties for DateTime objects

### DIFF
--- a/openapi3/codegen-templates/json_helper.mustache
+++ b/openapi3/codegen-templates/json_helper.mustache
@@ -12,10 +12,27 @@ function Remove-NullProperties {
 
     $NewObject = @{ }
     
+    # Handle null input
+    if ($null -eq $InputObject) {
+        return $null
+    }
+    
+    # Handle primitives and strings
     if ($InputObject -is [string] -or $InputObject.GetType().IsPrimitive) {
         return $InputObject
     }
-    elseif ($InputObject -is [System.Collections.IDictionary]) {
+    
+    # Handle value types that have self-referencing properties (Issue #75)
+    # These types should be returned as-is to avoid infinite recursion
+    if ($InputObject -is [DateTime] -or 
+        $InputObject -is [DateTimeOffset] -or 
+        $InputObject -is [Guid] -or 
+        $InputObject -is [Uri] -or 
+        $InputObject -is [TimeSpan]) {
+        return $InputObject
+    }
+    
+    if ($InputObject -is [System.Collections.IDictionary]) {
         $NewObject = Remove-NullPropertiesFromHashMap($InputObject)
     }
     elseif ($InputObject -is [array]){
@@ -52,6 +69,12 @@ function Remove-NullPropertiesFromHashMap{
     $OutputHashtable = @{}
     foreach ($Key in $InputObject.Keys) {
         $Value = $InputObject[$Key]
+        
+        # Skip null values early to avoid unnecessary processing
+        if ($null -eq $Value) {
+            continue
+        }
+        
         # explicit cast to avoid arrays to be converted to object (i.e @('foo'))
         if($Value -is [array]){
             [array]$CleanedValue = Remove-NullProperties $Value


### PR DESCRIPTION
## Problem
Update-OktaApplication with OIDC applications caused "call depth overflow" error when not using `-IncludeNullValues` flag.

## Root Cause
`DateTime` is a struct (value type), not a primitive. The `DateTime.Date` property returns another `DateTime`, creating infinite recursion: `DateTime → DateTime.Date → DateTime.Date.Date...` (200+ levels deep).

## Solution
Added explicit type checks for common .NET value types (`DateTime`, `DateTimeOffset`, `Guid`, `Uri`, `TimeSpan`) to return them as-is before recursive processing.

## Changes
- Updated `openapi3/codegen-templates/json_helper.mustache` (template)
- Updated `src/Okta.PowerShell/Client/JsonHelper.ps1` (generated)
- Added 7 regression tests in `tests/Client/JsonHelper.Tests.ps1`

## Testing
- All 12 JsonHelper tests pass
- Verified fix with real OIDC application
- Exact scenario from issue now works

Fixes #75 